### PR TITLE
Fix Issue with Incorrect BodyElement Generation

### DIFF
--- a/ksp/build.gradle.kts
+++ b/ksp/build.gradle.kts
@@ -10,7 +10,7 @@ mavenPublishing {
     coordinates(
         groupId = "io.github.cares0",
         artifactId = "rest-docs-kdsl-ksp",
-        version = "1.0.4"
+        version = "1.0.5"
     )
 
     pom {

--- a/ksp/src/main/kotlin/io/github/cares0/restdocskdsl/ksp/KspUtil.kt
+++ b/ksp/src/main/kotlin/io/github/cares0/restdocskdsl/ksp/KspUtil.kt
@@ -43,6 +43,11 @@ fun KSTypeReference.isServletApi(): Boolean {
     return this.getQualifiedName()?.startsWith("jakarta.servlet") ?: false
 }
 
+fun KSTypeReference.isArrayBasedType(): Boolean {
+    val typeName = this.getQualifiedName() ?: return false
+    return KotlinBuiltinName.isArrayBasedType(typeName)
+}
+
 fun KSTypeReference.isEnumType(): Boolean {
     return this.getAsIfKsClassDeclaration()?.classKind == ClassKind.ENUM_CLASS
 }
@@ -59,6 +64,11 @@ fun <T: Annotation> KSAnnotated.containsAnnotation(annotationClass: KClass<T>): 
 
 fun KSPropertyDeclaration.isGenericType(): Boolean {
     return this.type.resolve().declaration is KSTypeParameter
+}
+
+fun KSPropertyDeclaration.isArrayBasedType(): Boolean {
+    val typeName = this.type.getQualifiedName() ?: return false
+    return KotlinBuiltinName.isArrayBasedType(typeName)
 }
 
 fun KSPropertyDeclaration.getActualTypeOfTypeArgument(

--- a/ksp/src/main/kotlin/io/github/cares0/restdocskdsl/ksp/resolver/BodyElementExtractor.kt
+++ b/ksp/src/main/kotlin/io/github/cares0/restdocskdsl/ksp/resolver/BodyElementExtractor.kt
@@ -62,11 +62,24 @@ interface BodyElementExtractor {
         property: KSPropertyDeclaration,
     ): BodyElement {
         val typeArgumentReference = property.getActualTypeOfTypeArgument(parentTypeReference)!!
-        return createBodyElement(
-            name = property.simpleName.asString(),
-            nestedElementName = typeArgumentReference.getSimpleName(),
-            nestedElements = extractElements(typeArgumentReference)
-        )
+
+        if (KotlinBuiltinName.isArrayBasedType(typeArgumentReference.getQualifiedName()!!)) {
+            val arrayTypeArgumentReference = typeArgumentReference.getTypeArguments().first().type!!
+            val nestedElements = extractElements(arrayTypeArgumentReference)
+
+            return createBodyElement(
+                name = property.simpleName.asString(),
+                nestedElementName = if (nestedElements.isEmpty()) null else arrayTypeArgumentReference.getSimpleName(),
+                nestedElements = nestedElements.ifEmpty { null },
+                isArrayBasedType = true,
+            )
+        } else {
+            return createBodyElement(
+                name = property.simpleName.asString(),
+                nestedElementName = typeArgumentReference.getSimpleName(),
+                nestedElements = extractElements(typeArgumentReference)
+            )
+        }
     }
 
     fun handleCustomObjectType(

--- a/ksp/src/main/kotlin/io/github/cares0/restdocskdsl/ksp/resolver/BodyElementExtractor.kt
+++ b/ksp/src/main/kotlin/io/github/cares0/restdocskdsl/ksp/resolver/BodyElementExtractor.kt
@@ -19,81 +19,81 @@ interface BodyElementExtractor {
     ): BodyElement
 
     fun extractElements(ksTypeReference: KSTypeReference): List<BodyElement> {
-
         return ksTypeReference
             .getAsKsClassDeclaration()
             .getDeclaredProperties()
-            .mapNotNull { property -> handleProperty(ksTypeReference, property) }
+            .mapNotNull { property ->
+                handleProperty(
+                    parentType = ksTypeReference,
+                    property = property
+                )
+            }
             .toList()
     }
 
     fun handleProperty(
-        parentTypeReference: KSTypeReference,
+        parentType: KSTypeReference,
         property: KSPropertyDeclaration,
     ): BodyElement? {
-        val propertyTypeName = property.type.getQualifiedName()!!
+        var isArrayBasedType = false
+        var baseType = unwrapIfGenericType(parentType, property)
 
-        return when {
-            KotlinBuiltinName.isPrimitiveType(propertyTypeName)
-                    || propertyTypeName == KotlinBuiltinName.MAP
-                    || property.type.isJavaTimeApi() -> createBodyElement(property.simpleName.asString())
-            KotlinBuiltinName.isArrayBasedType(propertyTypeName) -> handleArrayBasedType(property)
-            property.isGenericType() -> handleGenericType(parentTypeReference, property)
-            else -> handleCustomObjectType(property)
+        if (baseType.isArrayBasedType()) {
+            baseType = baseType.getTypeArguments().first().type!!
+            isArrayBasedType = true
         }
-    }
 
-    fun handleArrayBasedType(
-        property: KSPropertyDeclaration,
-    ): BodyElement {
-        val typeArgumentReference = property.type.getTypeArguments().first().type!!
-        val nestedElements = extractElements(typeArgumentReference)
-
-        return createBodyElement(
-            name = property.simpleName.asString(),
-            nestedElementName = if (nestedElements.isEmpty()) null else typeArgumentReference.getSimpleName(),
-            nestedElements = nestedElements.ifEmpty { null },
-            isArrayBasedType = true,
+        return resolveBodyElement(
+            type = baseType,
+            elementName = property.simpleName.asString(),
+            isArrayBasedType = isArrayBasedType,
         )
     }
 
-    fun handleGenericType(
-        parentTypeReference: KSTypeReference,
+    private fun unwrapIfGenericType(
+        parentType: KSTypeReference,
         property: KSPropertyDeclaration,
-    ): BodyElement {
-        val typeArgumentReference = property.getActualTypeOfTypeArgument(parentTypeReference)!!
-
-        if (KotlinBuiltinName.isArrayBasedType(typeArgumentReference.getQualifiedName()!!)) {
-            val arrayTypeArgumentReference = typeArgumentReference.getTypeArguments().first().type!!
-            val nestedElements = extractElements(arrayTypeArgumentReference)
-
-            return createBodyElement(
-                name = property.simpleName.asString(),
-                nestedElementName = if (nestedElements.isEmpty()) null else arrayTypeArgumentReference.getSimpleName(),
-                nestedElements = nestedElements.ifEmpty { null },
-                isArrayBasedType = true,
-            )
-        } else {
-            return createBodyElement(
-                name = property.simpleName.asString(),
-                nestedElementName = typeArgumentReference.getSimpleName(),
-                nestedElements = extractElements(typeArgumentReference)
-            )
-        }
+    ): KSTypeReference {
+        return if (property.isGenericType()) property.getActualTypeOfTypeArgument(parentType)!!
+        else property.type
     }
 
-    fun handleCustomObjectType(
-        property: KSPropertyDeclaration,
+    fun resolveBodyElement(
+        type: KSTypeReference,
+        elementName: String,
+        isArrayBasedType: Boolean = false,
     ): BodyElement? {
-        val ksClassDeclaration = property.type.getAsIfKsClassDeclaration()
+        return if (isNotNestedType(type)) {
+            createBodyElement(
+                name = elementName,
+                isArrayBasedType = true
+            )
+        } else resolveNestedType(type, elementName, isArrayBasedType)
+    }
+
+    private fun isNotNestedType(type: KSTypeReference): Boolean {
+        val typeName = type.getQualifiedName()!!
+        return (KotlinBuiltinName.isPrimitiveType(typeName)
+                || typeName == KotlinBuiltinName.MAP
+                || type.isJavaTimeApi())
+    }
+
+    fun resolveNestedType(
+        propertyTypeReference: KSTypeReference,
+        propertyName: String,
+        isArrayBasedType: Boolean = false,
+    ): BodyElement? {
+        val ksClassDeclaration = propertyTypeReference.getAsIfKsClassDeclaration()
         if (ksClassDeclaration != null) {
             return when (ksClassDeclaration.classKind) {
-                ClassKind.ENUM_CLASS -> createBodyElement(property.simpleName.asString())
+                ClassKind.ENUM_CLASS -> createBodyElement(propertyName)
                 ClassKind.CLASS -> {
+                    val nestedElements = extractElements(propertyTypeReference)
                     createBodyElement(
-                        name = property.simpleName.asString(),
-                        nestedElementName = property.type.getSimpleName(),
-                        nestedElements = extractElements(property.type)
+                        name = propertyName,
+                        nestedElementName = propertyTypeReference.getSimpleName(),
+                        nestedElements = nestedElements.ifEmpty { null },
+                        isArrayBasedType = isArrayBasedType,
                     )
                 }
                 else -> return null


### PR DESCRIPTION
Fixed Issue with Incorrect BodyElement Generation for Custom Object Types in Request/Response Bodies
Resolved an issue where BodyElement was being generated incorrectly when the Request Body or Response Body was of a custom object type.

Specifically, properties within custom objects that were array-based or generic types sometimes resulted in unintended BodyComponent generation or the omission of necessary BodyComponents, leading to the incorrect creation of BodyElement.

Fixes: #1, #2 