### PR TITLE
Fix infinite recursion when processing self-referencing types

### DIFF
--- a/ksp/src/main/kotlin/io/github/cares0/restdocskdsl/ksp/resolver/BodyElementExtractor.kt
+++ b/ksp/src/main/kotlin/io/github/cares0/restdocskdsl/ksp/resolver/BodyElementExtractor.kt
@@ -18,22 +18,35 @@ interface BodyElementExtractor {
         isRootElement: Boolean = false,
     ): BodyElement
 
-    fun extractElements(ksTypeReference: KSTypeReference): List<BodyElement> {
-        return ksTypeReference
+    fun extractElements(
+        ksTypeReference: KSTypeReference,
+        visitedElements: MutableSet<String> = mutableSetOf(),
+    ): List<BodyElement> {
+        val typeName = ksTypeReference.getQualifiedName() ?: return emptyList()
+
+        if (!visitedElements.add(typeName)) return emptyList()
+
+        val elements = ksTypeReference
             .getAsKsClassDeclaration()
             .getDeclaredProperties()
             .mapNotNull { property ->
                 handleProperty(
                     parentType = ksTypeReference,
-                    property = property
+                    property = property,
+                    visitedElements = visitedElements,
                 )
             }
             .toList()
+
+        visitedElements.remove(typeName)
+
+        return elements
     }
 
     fun handleProperty(
         parentType: KSTypeReference,
         property: KSPropertyDeclaration,
+        visitedElements: MutableSet<String>,
     ): BodyElement? {
         var isArrayBasedType = false
         var baseType = unwrapIfGenericType(parentType, property)
@@ -47,6 +60,7 @@ interface BodyElementExtractor {
             type = baseType,
             elementName = property.simpleName.asString(),
             isArrayBasedType = isArrayBasedType,
+            visitedElements = visitedElements,
         )
     }
 
@@ -54,21 +68,32 @@ interface BodyElementExtractor {
         parentType: KSTypeReference,
         property: KSPropertyDeclaration,
     ): KSTypeReference {
-        return if (property.isGenericType()) property.getActualTypeOfTypeArgument(parentType)!!
-        else property.type
+        return if (property.isGenericType()) {
+            property.getActualTypeOfTypeArgument(parentType)!!
+        } else {
+            property.type
+        }
     }
 
     fun resolveBodyElement(
         type: KSTypeReference,
         elementName: String,
         isArrayBasedType: Boolean = false,
+        visitedElements: MutableSet<String>,
     ): BodyElement? {
         return if (isNotNestedType(type)) {
             createBodyElement(
                 name = elementName,
-                isArrayBasedType = true
+                isArrayBasedType = isArrayBasedType,
             )
-        } else resolveNestedType(type, elementName, isArrayBasedType)
+        } else {
+            resolveNestedType(
+                propertyTypeReference = type,
+                propertyName = elementName,
+                isArrayBasedType = isArrayBasedType,
+                visitedElements = visitedElements,
+            )
+        }
     }
 
     private fun isNotNestedType(type: KSTypeReference): Boolean {
@@ -82,24 +107,22 @@ interface BodyElementExtractor {
         propertyTypeReference: KSTypeReference,
         propertyName: String,
         isArrayBasedType: Boolean = false,
+        visitedElements: MutableSet<String>,
     ): BodyElement? {
-        val ksClassDeclaration = propertyTypeReference.getAsIfKsClassDeclaration()
-        if (ksClassDeclaration != null) {
-            return when (ksClassDeclaration.classKind) {
-                ClassKind.ENUM_CLASS -> createBodyElement(propertyName)
-                ClassKind.CLASS -> {
-                    val nestedElements = extractElements(propertyTypeReference)
-                    createBodyElement(
-                        name = propertyName,
-                        nestedElementName = propertyTypeReference.getSimpleName(),
-                        nestedElements = nestedElements.ifEmpty { null },
-                        isArrayBasedType = isArrayBasedType,
-                    )
-                }
-                else -> return null
-            }
-        }
-        return null
-    }
+        val ksClassDeclaration = propertyTypeReference.getAsIfKsClassDeclaration() ?: return null
 
+        return when (ksClassDeclaration.classKind) {
+            ClassKind.ENUM_CLASS -> createBodyElement(propertyName)
+            ClassKind.CLASS -> {
+                val nestedElements = extractElements(propertyTypeReference, visitedElements)
+                createBodyElement(
+                    name = propertyName,
+                    nestedElementName = propertyTypeReference.getSimpleName(),
+                    nestedElements = nestedElements.ifEmpty { null },
+                    isArrayBasedType = isArrayBasedType,
+                )
+            }
+            else -> null
+        }
+    }
 }

--- a/ksp/src/main/kotlin/io/github/cares0/restdocskdsl/ksp/resolver/KspHandlerElementResolver.kt
+++ b/ksp/src/main/kotlin/io/github/cares0/restdocskdsl/ksp/resolver/KspHandlerElementResolver.kt
@@ -40,7 +40,7 @@ class KspHandlerElementResolver(
     private val functionResolver = FunctionResolverComposite(
         environment,
         RequestCookieDocsAnnotationElementResolver(logger),
-        io.github.cares0.restdocskdsl.ksp.resolver.RequestHeaderDocsAnnotationElementResolver(logger),
+        RequestHeaderDocsAnnotationElementResolver(logger),
         SimpleResponseObjectResolver(logger),
         ArrayBasedResponseObjectResolver(logger),
         ResponseCookieElementResolver(logger),


### PR DESCRIPTION
This PR fixes an issue where generating DSL classes for types containing self-references caused a `StackOverflowError`.

**Problem:**  
When a data class contains a field of its own type (directly or indirectly), the recursive extraction logic (`extractElements`) repeatedly visited the same type without detecting the cycle, leading to a stack overflow.

**Solution:**  
A `visitedElements` set is introduced to track visited type names.  
Before processing a type, we now check if it has already been visited.  
If it has, we skip further extraction for that type to prevent infinite recursion.

Specifically:

- Before extracting properties, we attempt to add the type's qualified name to `visitedElements`.
    
- If the type has already been visited (`!visitedElements.add(typeName)`), an empty list is returned immediately, avoiding recursion.
    

**Example Scenario Solved:**

```kotlin
data class ResponseA(
     val name: String,
     val children: List<ResponseA>, 
)
```

In this case, the `children` list no longer causes an infinite loop when generating the DSL.